### PR TITLE
TabBar実装

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,19 @@
+import TabBar from "@/components/layout/TabBar";
+
 export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <div className="min-h-screen bg-gray-background">
+      {/* タブバー */}
+      <TabBar />
+
+      {/* メインコンテンツ */}
+      <main className="md:ml-60 pb-16 md:pb-0">
+        {children}
+      </main>
+    </div>
+  );
 }

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { NavLink } from "@/types/navlink.types";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+// ボトムナビバーコンポーネント (モバイル用)
+export function BottomNav({ links }: { links: NavLink[] }) {
+    const pathname = usePathname();
+
+    return (
+        <nav className="block md:hidden fixed bottom-0 left-0 right-0 h-20 bg-background">
+            <div className="flex items-center justify-around h-full px-2">
+                {links.map((link) => {
+                    const Icon = link.icon;
+                    const isActive = pathname === link.href;
+
+                    return (
+                        <Link
+                            key={link.href}
+                            href={link.href}
+                            className="flex flex-col items-center justify-center gap-1 px-4 py-2 rounded-lg text-primary-text hover:bg-gray-background transition-colors"
+                        >
+                            <Icon
+                                className={`w-6 h-6 ${isActive ? "text-primary" : "text-primary-text"}`}
+                                strokeWidth={isActive ? 2.5 : 2}
+                            />
+                        </Link>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { NavLink } from "@/types/navlink.types";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import Heading from "../ui/Heading";
+
+// サイドバーコンポーネント (PC用)
+export function Sidebar({ links }: { links: NavLink[] }) {
+    const pathname = usePathname();
+
+    return (
+        <aside className="hidden md:block fixed left-0 top-0 h-full w-56 bg-background">
+            <div className="p-8">
+                <Heading level="h1" className="pb-8">Mimo</Heading>
+                <nav className="space-y-2">
+                    {links.map((link) => {
+                        const Icon = link.icon;
+                        const isActive = pathname === link.href;
+
+                        return (
+                            <Link
+                                key={link.href}
+                                href={link.href}
+                                className="flex items-center gap-3 py-3 rounded-lg text-primary-text hover:bg-gray-background transition-colors"
+                            >
+                                <Icon
+                                    className={`w-6 h-6 ${isActive ? "text-primary" : "text-primary-text"}`}
+                                    strokeWidth={isActive ? 2.5 : 2}
+                                />
+                                <span className={isActive ? "font-bold" : "font-medium"}>
+                                    {link.label}
+                                </span>
+                            </Link>
+                        );
+                    })}
+                </nav>
+            </div>
+        </aside>
+    );
+}

--- a/components/layout/TabBar.tsx
+++ b/components/layout/TabBar.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { NavLink } from "@/types/navlink.types";
+import { Sidebar } from "./Sidebar";
+import { BottomNav } from "./BottomNav";
+import { MessageSquare, List, Settings } from "lucide-react";
+
+// ナビゲーションリンク配列
+const navLinks: NavLink[] = [
+  { href: "/", label: "ホーム", icon: MessageSquare },
+  { href: "/list", label: "リスト", icon: List },
+  { href: "/setting", label: "設定", icon: Settings },
+];
+
+export default function TabBar() {
+  return (
+    <>
+      {/* サイドバー (PC) */}
+      <Sidebar links={navLinks} />
+
+      {/* ボトムナビバー (モバイル) */}
+      <BottomNav links={navLinks} />
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "lucide-react": "^0.553.0",
         "next": "16.0.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -5363,6 +5364,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "lucide-react": "^0.553.0",
     "next": "16.0.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/types/navlink.types.ts
+++ b/types/navlink.types.ts
@@ -1,0 +1,7 @@
+import { LucideIcon } from "lucide-react";
+
+export interface NavLink {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}


### PR DESCRIPTION

## 概要
<!-- このPRが解決する問題や、実装する機能の概要を記述してください。 -->

Fixes #10 

Sidebar（PC）, BottomNav（スマホ）を実装しTabBarでレスポンシブに切り替えるように実装。
main/layoutにTabBarを統合し、サイドバーとボトムナビバーを表示。
ナビゲーションリンクの型を定義し、lucide-reactを依存関係に追加。

## 変更内容
### 修正前
- タブバーがなかった

### 修正後
- TabBarを実装
    - types/navlink.types.tsを定義
    - Sidebar（PC）
    - BottomNav（スマホ）
- lucide-reactをアイコン用として依存関係に追加

## 動作確認
<!-- UIの変更など、視覚的な変更がある場合は、変更前後のスクリーンショットを貼ってください。 -->

| 修正前 | 修正後 |
|--------|--------|
|  <img src="URL" width="400">  |  <img src="https://github.com/user-attachments/assets/a682ef9e-a506-4de1-9529-870e3aa504d1" width="600">  |
|  <img src="URL" width="400">  |  <img src="https://github.com/user-attachments/assets/88cc05c8-6e10-4465-a69b-053052b7432a" width="600">  |


### 確認手順
- [修正されたことをどのように確認したか]
- http://localhost:3000/ を確認

## チェックリスト
<!-- 以下の項目を確認してチェックをつけてください -->

### 開発・テスト
- [x] 影響範囲の確認をした
- [x] テストは通った
- [x] エラーハンドリングを確認した

### ドキュメント・その他
- [x] 必要に応じてドキュメントを更新した
- [x] コードレビューの準備ができている
- [x] 関連するIssueにリンクしている
- [x] 破壊的変更がある場合は明記した

## その他
<!-- 補足事項、懸念点、レビュアーに特に見てほしいポイントなどがあれば記述してください。 -->
なし